### PR TITLE
chore: release v2.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <a name="x.y.z-dev" data-comment="this line is used by gitmoji-changelog, don't remove it!"></a>
 
+## [2.13.6](https://github.com/ffizer/ffizer/compare/2.13.5...2.13.6) - 2025-12-10
+
+### <!-- 1 -->Fixed
+
+- correct homebrew package name
+
+### <!-- 2 -->Added
+
+- *(README)* add download-history
+
 ## [2.13.4](https://github.com/ffizer/ffizer/compare/2.13.3...2.13.4) - 2025-09-17
 
 ## [2.13.3](https://github.com/ffizer/ffizer/compare/2.13.2...2.13.3) - 2025-06-03

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffizer"
-version = "2.13.5"
+version = "2.13.6"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffizer"
-version = "2.13.5"
+version = "2.13.6"
 authors = ["David Bernard"]
 description = """ffizer is a files and folders initializer / generator.
 It creates or updates any kind (or part) of project from template(s)"""


### PR DESCRIPTION



## 🤖 New release

* `ffizer`: 2.13.5 -> 2.13.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.6](https://github.com/ffizer/ffizer/compare/2.13.5...2.13.6) - 2025-12-10

### <!-- 1 -->Fixed

- correct homebrew package name

### <!-- 2 -->Added

- *(README)* add download-history
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).