### PR TITLE
chore: release v2.13.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <a name="x.y.z-dev" data-comment="this line is used by gitmoji-changelog, don't remove it!"></a>
 
+## [2.13.10](https://github.com/ffizer/ffizer/compare/2.13.9...2.13.10) - 2026-04-27
+
+### <!-- 1 -->Fixed
+
+- *(deps)* update
+
 ## [2.13.9](https://github.com/ffizer/ffizer/compare/2.13.8...2.13.9) - 2026-04-07
 
 ### <!-- 1 -->Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ffizer"
-version = "2.13.9"
+version = "2.13.10"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffizer"
-version = "2.13.9"
+version = "2.13.10"
 description = """ffizer is a files and folders initializer / generator.
 It creates or updates any kind (or part) of project from template(s)"""
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `ffizer`: 2.13.9 -> 2.13.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.10](https://github.com/ffizer/ffizer/compare/2.13.9...2.13.10) - 2026-04-27

### <!-- 1 -->Fixed

- *(deps)* update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).