### PR TITLE
chore: release v2.13.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ffizer"
-version = "2.13.12"
+version = "2.13.13"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffizer"
-version = "2.13.12"
+version = "2.13.13"
 description = """ffizer is a files and folders initializer / generator.
 It creates or updates any kind (or part) of project from template(s)"""
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `ffizer`: 2.13.12 -> 2.13.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.12](https://github.com/ffizer/ffizer/compare/2.13.11...2.13.12) - 2026-07-14

### <!-- 1 -->Fixed

- *(deps)* update rust, deps,...
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).